### PR TITLE
Various updates, including `info` and `extract --all` additions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -59,6 +68,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -77,10 +92,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
+name = "cc"
+version = "1.2.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link 0.2.0",
+]
 
 [[package]]
 name = "clap"
@@ -142,6 +180,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "deranged"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -173,6 +217,12 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "foldhash"
@@ -211,10 +261,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "ibackupextractor"
 version = "0.1.1"
 dependencies = [
  "anyhow",
+ "chrono",
  "clap",
  "console",
  "fallible-iterator",
@@ -302,6 +377,15 @@ name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "once_cell"
@@ -399,6 +483,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "serde"
 version = "1.0.225"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -426,6 +516,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "smallvec"
@@ -519,6 +615,7 @@ checksum = "ab10a69fbd0a177f5f649ad4d8d3305499c42bab9aef2f7ff592d0ec8f833819"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
 ]
@@ -580,6 +677,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6844ee5416b285084d3d3fffd743b925a6c9385455f64f6d4fa3031c4c2749a9"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.2.0",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -590,6 +722,24 @@ name = "windows-link"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+
+[[package]]
+name = "windows-result"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7084dcc306f89883455a206237404d3eaf961e5bd7e0f312f7c91f57eb44167f"
+dependencies = [
+ "windows-link 0.2.0",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7218c655a553b0bed4426cf54b20d7ba363ef543b52d515b3e48d7fd55318dda"
+dependencies = [
+ "windows-link 0.2.0",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,7 +286,7 @@ dependencies = [
 
 [[package]]
 name = "ibackupextractor"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ibackupextractor"
 description = "A simple tool for extracting files from iOS backup archive."
-version = "0.1.1"
+version = "0.2.0"
 edition = "2024"
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ plist = "1"
 console = "0.16"
 indicatif = "0.18"
 clap = { version = "4", features = ["derive"] }
+chrono = "0.4"

--- a/README.md
+++ b/README.md
@@ -4,13 +4,10 @@ A simple tool for extracting files from iOS backup archive.
 
 iOS backup files are not stored with their original directory
 layouts. Retrieving a particular file from the app sandbox can be
-difficult. This tool can extract all the files from a backup archive,
-and then you can view the sandbox filesystem as it was originally
-stored in your iPhone or iPad.
+difficult. This tool can extract files from a backup archive, and then
+you can view the sandbox filesystem as it was originally stored in
+your iPhone or iPad.
 
-To save disk usage and speed up the extraction process, by default the
-tool creates symbolic links to the original files in the backup
-archive. If desired, files can also be copied.
 
 ## Install
 
@@ -37,9 +34,9 @@ be found in
 **The archive is a directory that contains a `Manifest.db` file.**
 
 Except when performing migrations, `Manifest.db` is opened in
-read-only mode, so it can list domains and extract files even when the
-archive is on a read-only filesystem (e.g. HFS+ on Linux).
-However, never work on the only copy of your data!
+read-only mode, so it will work even when the archive is on a
+read-only filesystem (e.g. HFS+ on Linux).  However, never work on the
+only copy of your data!
 
 ### Show Backup Information
 
@@ -77,14 +74,14 @@ ibackupextractor extract -d SomeDomain /path/to/your_backup_archive /path/to/des
 
 An empty destination directory is recommended.
 
-In addition to the default symbolic-link mode, the `extract`
-subcommand can also create a copy of each extracted file in the
-destination directory, by specifying `-c` (or `--copy`).
+By default, `extract` _copies_ each file to the destination
+directory. To save disk space, use the `-L` (or `--link`) option to
+create symbolic links instead of copies.
 
-For example, to copy Camera Roll files from an archive:
+For example, to copy all Camera Roll files from an archive:
 
 ```
-ibackupextractor extract -c -d CameraRollDomain /path/to/your_backup_archive /path/to/dest_dir
+ibackupextractor extract -d CameraRollDomain /path/to/your_backup_archive /path/to/dest_dir
 ```
 
 ### Migrate a Domain Between Backups
@@ -97,12 +94,9 @@ structure:
 ibackupextractor migrate -d SomeDomain /path/to/source_backup_archive /path/to/dest_backup_archive
 ```
 
-As with extraction, you can switch to copy mode with `-c` so that real
-files are created in the destination backup archive:
-
-```
-ibackupextractor migrate -c -d SomeDomain /path/to/source_backup_archive /path/to/dest_backup_archive
-```
+As with extraction, `migrate` copies files between backups by default.
+Add `-L` if you want symbolic links instead of real files in the destination
+archive.
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ inside the archive.
 ### List Domains
 
 Backup files are grouped by "domains", and the `list-domains`
-subcommand will show all of those included in a particular archive:
+subcommand will show all the domains in a particular archive,
+sorted by the size of exportable data in each:
 
 ```
 ibackupextractor list-domains /path/to/your_backup_archive

--- a/README.md
+++ b/README.md
@@ -2,15 +2,23 @@
 
 A simple tool for extracting files from iOS backup archive.
 
-iOS backup files are not stored with their original directory layouts. Retrieving a particular file from the app sandbox can be difficult. This tool can extract all the files from a backup archive, and then you can view the sandbox filesystem as it was originally stored in your iPhone or iPad.
+iOS backup files are not stored with their original directory
+layouts. Retrieving a particular file from the app sandbox can be
+difficult. This tool can extract all the files from a backup archive,
+and then you can view the sandbox filesystem as it was originally
+stored in your iPhone or iPad.
 
-To save disk usage and speed up the extraction process, the extracted files are symbolic links to the original files in the backup archive.
+To save disk usage and speed up the extraction process, by default the
+tool creates symbolic links to the original files in the backup
+archive. If desired, files can also be copied.
 
 ## Install
 
 ### Download From GitHub Releases
 
-For Mac users, you can download the pre-built binaries directly from [releases](https://github.com/unixzii/ibackupextractor/releases) page.
+For Mac users, you can download the pre-built binaries directly from
+the [releases](https://github.com/unixzii/ibackupextractor/releases)
+page.
 
 ### Build Locally
 
@@ -22,23 +30,35 @@ cargo build --release
 
 ## Usage
 
-Locate the backup archive you want to extract. Generally, you can find it under `/Users/cyandev/Library/Application Support/MobileSync/Backup`. **The archive is a directory that contains `Manifest.db` file.**
+First, locate the backup archive you want to extract. Usually, it can
+be found in 
+`/Users/<username>/Library/Application Support/MobileSync/Backup`.
 
-The tool opens `Manifest.db` in read-only mode, so it can list domains and extract files even when the archive is mounted from read-only media such as external HFS+ disks.
+**The archive is a directory that contains a `Manifest.db` file.**
+
+Except when performing migrations, `Manifest.db` is opened in
+read-only mode, so it can list domains and extract files even when the
+archive is on a read-only filesystem (e.g. HFS+ on Linux).
+However, never work on the only copy of your data!
 
 ### Show Backup Information
 
-Use the `info` subcommand to get a summary of the entire archive, including the manifest location, timestamps, device and iTunes metadata, total files/domains, and the overall size on disk:
+The `info` subcommand shows a summary of the backup archive,
+including the manifest location, timestamps, device and iTunes
+metadata, total files/domains, and the overall size on disk:
 
 ```
 ibackupextractor info /path/to/your_backup_archive
 ```
 
-`info` covers archive-level metadata while `list-domains` still focuses on the domains inside the archive, so the outputs remain complementary.
+In general, the `info` shows _archive-level_ metadata, while
+`list-domains` (see below) shows information related to the _domains_
+inside the archive.
 
 ### List Domains
 
-Backup files are grouped by domains, and you can ask the binary to enumerate them with the `list-domains` subcommand. It only requires the path to the backup archive:
+Backup files are grouped by "domains", and the `list-domains`
+subcommand will show all of those included in a particular archive:
 
 ```
 ibackupextractor list-domains /path/to/your_backup_archive
@@ -46,25 +66,34 @@ ibackupextractor list-domains /path/to/your_backup_archive
 
 ### Extract a Specified Domain
 
-To extract files, invoke the `extract` subcommand with the archive path, the destination directory, and the domain name via `-d`/`--domain`. An empty directory is recommended:
-
+To extract files, use the `extract` subcommand with the archive path,
+a desired destination directory, and the domain to extract with
+`-d`/`--domain`: 
 ```
 ibackupextractor extract /path/to/your_backup_archive /path/to/dest_dir -d SomeDomain
 ```
 
-The extraction process can take minutes to finish, depending on the number of files.
+An empty destination directory is recommended.
 
-In addition to the default symbolic-link mode, you can also change to copy mode by specifying `-c` (or `--copy`). In copy mode, all files are copied to the destination path, and then you can delete the original backup archive freely if you want.
+The extraction process can take minutes to finish, depending on the
+number of files.
+
+In addition to the default symbolic-link mode, the `extract`
+subcommand can also create a copy of each extracted file in the
+destination directory, by specifying `-c` (or `--copy`).
 
 ### Migrate a Domain Between Backups
 
-The `migrate` subcommand lets you copy files in a domain from one backup archive to another while preserving the original directory structure:
+The `migrate` subcommand lets you transfer files by domain from one
+backup archive to another, while preserving the original directory
+structure:
 
 ```
 ibackupextractor migrate -d SomeDomain /path/to/source_backup_archive /path/to/dest_backup_archive
 ```
 
-As with extraction, you can switch to copy mode with `-c` so that real files are created in the destination backup archive:
+As with extraction, you can switch to copy mode with `-c` so that real
+files are created in the destination backup archive:
 
 ```
 ibackupextractor migrate -c -d SomeDomain /path/to/source_backup_archive /path/to/dest_backup_archive
@@ -72,19 +101,22 @@ ibackupextractor migrate -c -d SomeDomain /path/to/source_backup_archive /path/t
 
 ## FAQ
 
-### How to create a proper backup archive?
+### How do I create a backup archive that this tool can use?
 
-This tool can only handle the backup archives that are unencrypted. To backup without encryption, uncheck the following option before starting:
+This tool can only handle the backup archives that are unencrypted. To
+backup without encryption, uncheck the following option before
+starting:
 
 ![Disable Encryption](./docs/figure-1.png)
 
 ### Will this tool modify the original backup archive?
 
-No, the tool will not write to any file in the backup archive.
+The `info`, `list-domains`, and `extract` commands do not write to the
+backup archive, and only read access to the archive is required.
 
-### Can I run this against archives on read-only storage?
-
-Yes. The manifest database is opened with SQLite read-only flags so the tool never tries to create journal files, which allows it to read backups stored on read-only volumes (for example, Apple backup folders mounted from HFS+ disks).
+The `migrate` command writes to the _destination_ archive only.  To
+successfully run `migrate`, read/write access to the destination
+archive is required.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ cargo build --release
 
 Locate the backup archive you want to extract. Generally, you can find it under `/Users/cyandev/Library/Application Support/MobileSync/Backup`. **The archive is a directory that contains `Manifest.db` file.**
 
+The tool opens `Manifest.db` in read-only mode, so it can list domains and extract files even when the archive is mounted from read-only media such as external HFS+ disks.
+
 ### List Domains
 
 Backup files are grouped by domains, and you can ask the binary to enumerate them with the `list-domains` subcommand. It only requires the path to the backup archive:
@@ -69,6 +71,10 @@ This tool can only handle the backup archives that are unencrypted. To backup wi
 ### Will this tool modify the original backup archive?
 
 No, the tool will not write to any file in the backup archive.
+
+### Can I run this against archives on read-only storage?
+
+Yes. The manifest database is opened with SQLite read-only flags so the tool never tries to create journal files, which allows it to read backups stored on read-only volumes (for example, Apple backup folders mounted from HFS+ disks).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -51,15 +51,15 @@ metadata, total files/domains, and the overall size on disk:
 ibackupextractor info /path/to/your_backup_archive
 ```
 
-In general, the `info` shows _archive-level_ metadata, while
+The `info` command is designed to show _archive-level_ metadata, while
 `list-domains` (see below) shows information related to the _domains_
 inside the archive.
 
 ### List Domains
 
-Backup files are grouped by "domains", and the `list-domains`
-subcommand will show all the domains in a particular archive,
-sorted by the size of exportable data in each:
+Backup files are grouped by iOS "domains", and the `list-domains`
+subcommand will show all the domains in a particular archive, sorted
+by the amount of exportable data in each:
 
 ```
 ibackupextractor list-domains /path/to/your_backup_archive
@@ -67,21 +67,25 @@ ibackupextractor list-domains /path/to/your_backup_archive
 
 ### Extract a Specified Domain
 
-To extract files, use the `extract` subcommand with the archive path,
-a desired destination directory, and the domain to extract with
-`-d`/`--domain`: 
+To extract files, use the `extract` subcommand followed by `-d` and
+the name of the domain to extract, then the path to the archive
+directory, and then a destination directory:
+
 ```
-ibackupextractor extract /path/to/your_backup_archive /path/to/dest_dir -d SomeDomain
+ibackupextractor extract -d SomeDomain /path/to/your_backup_archive /path/to/dest_dir
 ```
 
 An empty destination directory is recommended.
 
-The extraction process can take minutes to finish, depending on the
-number of files.
-
 In addition to the default symbolic-link mode, the `extract`
 subcommand can also create a copy of each extracted file in the
 destination directory, by specifying `-c` (or `--copy`).
+
+For example, to copy Camera Roll files from an archive:
+
+```
+ibackupextractor extract -c -d CameraRollDomain /path/to/your_backup_archive /path/to/dest_dir
+```
 
 ### Migrate a Domain Between Backups
 
@@ -104,9 +108,9 @@ ibackupextractor migrate -c -d SomeDomain /path/to/source_backup_archive /path/t
 
 ### How do I create a backup archive that this tool can use?
 
-This tool can only handle the backup archives that are unencrypted. To
-backup without encryption, uncheck the following option before
-starting:
+**This tool can only handle the backup archives that are
+unencrypted.** To backup without encryption, uncheck the following
+option before starting:
 
 ![Disable Encryption](./docs/figure-1.png)
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ Locate the backup archive you want to extract. Generally, you can find it under 
 
 The tool opens `Manifest.db` in read-only mode, so it can list domains and extract files even when the archive is mounted from read-only media such as external HFS+ disks.
 
+### Show Backup Information
+
+Use the `info` subcommand to get a summary of the entire archive, including the manifest location, timestamps, device and iTunes metadata, total files/domains, and the overall size on disk:
+
+```
+ibackupextractor info /path/to/your_backup_archive
+```
+
+`info` covers archive-level metadata while `list-domains` still focuses on the domains inside the archive, so the outputs remain complementary.
+
 ### List Domains
 
 Backup files are grouped by domains, and you can ask the binary to enumerate them with the `list-domains` subcommand. It only requires the path to the backup archive:

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ A simple tool for extracting files from iOS backup archive.
 
 iOS backup files are not stored with their original directory
 layouts. Retrieving a particular file from the app sandbox can be
-difficult. This tool can extract files from a backup archive, and then
-you can view the sandbox filesystem as it was originally stored in
-your iPhone or iPad.
+difficult. This tool can extract all the files from a backup archive,
+and then you can view the sandbox filesystem as it was originally
+stored in your iPhone or iPad.
 
 
 ## Install
@@ -27,9 +27,9 @@ cargo build --release
 
 ## Usage
 
-First, locate the backup archive you want to extract. Usually, it can
+First, locate the backup archive you want to extract. Usually, they can
 be found in 
-`/Users/<username>/Library/Application Support/MobileSync/Backup`.
+`/Users/<username>/Library/Application Support/MobileSync/Backup`
 
 **The archive is a directory that contains a `Manifest.db` file.**
 
@@ -62,27 +62,31 @@ by the amount of exportable data in each:
 ibackupextractor list-domains /path/to/your_backup_archive
 ```
 
-### Extract a Specified Domain
+### Extracting Files
 
-To extract files, use the `extract` subcommand followed by `-d` and
-the name of the domain to extract, then the path to the archive
-directory, and then a destination directory:
+To extract files, use the `extract` subcommand, followed by either
+`-d` to select a particular domain or `--all` to extract every domain
+with data, then the path to the archive directory, and a destination
+directory to write the extracted data to.
+
+For example, to extract all files from an archive, run:
+
+```
+ibackupextractor extract --all /path/to/your_backup_archive /path/to/dest_dir
+```
+
+Or to only export files from 'SomeDomain', run:
 
 ```
 ibackupextractor extract -d SomeDomain /path/to/your_backup_archive /path/to/dest_dir
 ```
 
-An empty destination directory is recommended.
+An empty destination directory is recommended. An error will result if
+the tool attempts to write over an existing file.
 
-By default, `extract` _copies_ each file to the destination
-directory. To save disk space, use the `-L` (or `--link`) option to
-create symbolic links instead of copies.
-
-For example, to copy all Camera Roll files from an archive:
-
-```
-ibackupextractor extract -d CameraRollDomain /path/to/your_backup_archive /path/to/dest_dir
-```
+By default, `extract` _copies_ each file to the destination directory.
+To save disk space, use the `-L` (or `--link`) option to create symbolic
+links instead of copies.
 
 ### Migrate a Domain Between Backups
 

--- a/README.md
+++ b/README.md
@@ -14,16 +14,10 @@ For Mac users, you can download the pre-built binaries directly from [releases](
 
 ### Build Locally
 
-To build this locally, a nightly toolchain is required. You can install it using `rustup`:
+To build the project locally, use Cargo:
 
 ```
-rustup toolchain install nightly
-```
-
-Then, you can build the executable:
-
-```
-cargo +nightly build --release
+cargo build --release
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -26,23 +26,23 @@ Locate the backup archive you want to extract. Generally, you can find it under 
 
 ### List Domains
 
-Backup files are grouped by domains, and you need to specify a domain name when extracting. To list all the domains available, run the command below:
+Backup files are grouped by domains, and you can ask the binary to enumerate them with the `list-domains` subcommand. It only requires the path to the backup archive:
 
 ```
-ibackupextractor -l /path/to/your_backup_archive
+ibackupextractor list-domains /path/to/your_backup_archive
 ```
 
 ### Extract a Specified Domain
 
-To extract files, you need to specify a domain name and a destination path (an empty directory is recommended):
+To extract files, invoke the `extract` subcommand with the archive path, the destination directory, and the domain name via `-d`/`--domain`. An empty directory is recommended:
 
 ```
-ibackupextractor -o /path/to/dest_dir /path/to/your_backup_archive SomeDomain
+ibackupextractor extract /path/to/your_backup_archive /path/to/dest_dir -d SomeDomain
 ```
 
-The extraction process can take minutes to finish, depends on the number of files.
+The extraction process can take minutes to finish, depending on the number of files.
 
-In addition to the default symbolic-link mode, you can also change to copy mode by specifying `-c` flag. In copy mode, all files are copied to the destination path, and then you can delete the original backup archive freely if you want.
+In addition to the default symbolic-link mode, you can also change to copy mode by specifying `-c` (or `--copy`). In copy mode, all files are copied to the destination path, and then you can delete the original backup archive freely if you want.
 
 ### Migrate a Domain Between Backups
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "stable"

--- a/src/app.rs
+++ b/src/app.rs
@@ -4,7 +4,8 @@ use crate::Backup;
 use crate::cli::{Args, Command};
 use crate::db::BackupManifest;
 use crate::info::print_backup_info;
-use crate::utils;
+use crate::utils::{format_bytes, PerfTimer};
+use std::cmp::Reverse;
 
 mod progress_bar {
     use std::sync::mpsc::{Receiver, Sender, channel};
@@ -116,14 +117,29 @@ pub fn run(args: Args) -> Result<()> {
 
     match &args.command {
         Command::ListDomains { .. } => {
-            let timer = utils::PerfTimer::new();
-            let domains = src_backup
-                .list_domains()
+            let timer = PerfTimer::new();
+            let mut domains = src_backup
+                .domain_summaries()
                 .context("failed to list domains")?;
+            domains.sort_by_key(|domain| Reverse(domain.exportable_size));
             timer.finish();
 
-            for domain in domains {
-                println!("{domain}");
+            let formatted_domains: Vec<_> = domains
+                .into_iter()
+                .map(|domain| {
+                    let size_text = format_bytes(domain.exportable_size);
+                    (size_text, domain.domain)
+                })
+                .collect();
+
+            let size_column_width = formatted_domains
+                .iter()
+                .map(|(size, _)| size.len())
+                .max()
+                .unwrap_or(0);
+
+            for (size_text, domain_name) in formatted_domains {
+                println!("{size_text:>width$} {}", domain_name, width = size_column_width);
             }
         }
         Command::Migrate {
@@ -131,7 +147,7 @@ pub fn run(args: Args) -> Result<()> {
             domain,
             ..
         } => {
-            let timer = utils::PerfTimer::new();
+            let timer = PerfTimer::new();
             let pb_port = progress_bar::make();
 
             let manifest_path = dest_backup_dir.join("Manifest.db");
@@ -158,7 +174,7 @@ pub fn run(args: Args) -> Result<()> {
         Command::Extract {
             out_dir, domain, ..
         } => {
-            let timer = utils::PerfTimer::new();
+            let timer = PerfTimer::new();
             let pb_port = progress_bar::make();
             src_backup
                 .extract_file(

--- a/src/app.rs
+++ b/src/app.rs
@@ -4,7 +4,7 @@ use crate::Backup;
 use crate::cli::{Args, Command};
 use crate::db::BackupManifest;
 use crate::info::print_backup_info;
-use crate::utils::{format_bytes, PerfTimer};
+use crate::utils::{PerfTimer, format_bytes};
 use std::cmp::Reverse;
 
 mod progress_bar {
@@ -139,7 +139,11 @@ pub fn run(args: Args) -> Result<()> {
                 .unwrap_or(0);
 
             for (size_text, domain_name) in formatted_domains {
-                println!("{size_text:>width$} {}", domain_name, width = size_column_width);
+                println!(
+                    "{size_text:>width$} {}",
+                    domain_name,
+                    width = size_column_width
+                );
             }
         }
         Command::Migrate {
@@ -172,19 +176,33 @@ pub fn run(args: Args) -> Result<()> {
             timer.finish();
         }
         Command::Extract {
-            out_dir, domain, ..
+            out_dir,
+            domain,
+            all,
+            ..
         } => {
             let timer = PerfTimer::new();
             let pb_port = progress_bar::make();
-            src_backup
-                .extract_file(
-                    domain.as_ref().expect("domain should not be empty"),
-                    &out_dir,
-                    |event| {
+
+            let targets = if *all {
+                src_backup
+                    .domain_summaries()
+                    .context("failed to list domains")?
+                    .into_iter()
+                    .filter(|summary| summary.exportable_size > 0)
+                    .map(|summary| summary.domain)
+                    .collect::<Vec<_>>()
+            } else {
+                vec![domain.as_ref().expect("domain should not be empty").clone()]
+            };
+
+            for target in targets {
+                src_backup
+                    .extract_file(&target, &out_dir, |event| {
                         pb_port.send(event);
-                    },
-                )
-                .context("failed to extract files")?;
+                    })
+                    .with_context(|| format!("failed to extract domain {target}"))?;
+            }
 
             drop(pb_port);
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,12 +1,13 @@
 use anyhow::{Context, Result};
 
+use crate::Backup;
 use crate::cli::{Args, Command};
 use crate::db::BackupManifest;
+use crate::info::print_backup_info;
 use crate::utils;
-use crate::Backup;
 
 mod progress_bar {
-    use std::sync::mpsc::{channel, Receiver, Sender};
+    use std::sync::mpsc::{Receiver, Sender, channel};
     use std::thread::{Builder as ThreadBuilder, JoinHandle};
     use std::time::Duration;
 
@@ -103,8 +104,13 @@ pub fn run(args: Args) -> Result<()> {
     let backup_dir = args.backup_dir();
 
     let manifest_path = backup_dir.join("Manifest.db");
-    let manifest = BackupManifest::open_read_only(manifest_path)
+    let manifest = BackupManifest::open_read_only(manifest_path.clone())
         .context("failed to open the manifest database")?;
+
+    if matches!(&args.command, Command::Info { .. }) {
+        print_backup_info(backup_dir, &manifest_path, &manifest)?;
+        return Ok(());
+    }
 
     let src_backup = Backup::new(backup_dir, manifest, args.copy_mode());
 
@@ -168,6 +174,7 @@ pub fn run(args: Args) -> Result<()> {
 
             timer.finish();
         }
+        Command::Info { .. } => unreachable!("info command handled before src backup creation"),
     }
 
     Ok(())

--- a/src/app.rs
+++ b/src/app.rs
@@ -103,8 +103,8 @@ pub fn run(args: Args) -> Result<()> {
     let backup_dir = args.backup_dir();
 
     let manifest_path = backup_dir.join("Manifest.db");
-    let manifest =
-        BackupManifest::open(manifest_path).context("failed to open the manifest database")?;
+    let manifest = BackupManifest::open_read_only(manifest_path)
+        .context("failed to open the manifest database")?;
 
     let src_backup = Backup::new(backup_dir, manifest, args.copy_mode());
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -139,11 +139,7 @@ pub fn run(args: Args) -> Result<()> {
                 .unwrap_or(0);
 
             for (size_text, domain_name) in formatted_domains {
-                println!(
-                    "{size_text:>width$} {}",
-                    domain_name,
-                    width = size_column_width
-                );
+                println!("{size_text:>size_column_width$} {domain_name}");
             }
         }
         Command::Migrate {
@@ -198,7 +194,7 @@ pub fn run(args: Args) -> Result<()> {
 
             for target in targets {
                 src_backup
-                    .extract_file(&target, &out_dir, |event| {
+                    .extract_file(&target, out_dir, |event| {
                         pb_port.send(event);
                     })
                     .with_context(|| format!("failed to extract domain {target}"))?;

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -162,7 +162,7 @@ impl Backup {
             let dest_file_path = self.original_file_path(file_id);
             let dir = dest_file_path.parent().expect("path should have a parent");
             if !dir.exists() {
-                fs::create_dir_all(&dir).with_context(|| {
+                fs::create_dir_all(dir).with_context(|| {
                     format!("failed to create directory: {}", dir.to_string_lossy())
                 })?;
             }

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -13,6 +13,11 @@ pub struct Backup {
     copy_mode: bool,
 }
 
+pub struct DomainSummary {
+    pub domain: String,
+    pub exportable_size: u64,
+}
+
 impl Backup {
     pub fn new<P: Into<PathBuf>>(backup_dir: P, manifest: BackupManifest, copy_mode: bool) -> Self {
         Self {
@@ -22,8 +27,39 @@ impl Backup {
         }
     }
 
-    pub fn list_domains(&self) -> Result<Vec<String>> {
-        self.manifest.query_domains()
+    pub fn domain_summaries(&self) -> Result<Vec<DomainSummary>> {
+        let domains = self.manifest.query_domains()?;
+        let mut summaries = Vec::with_capacity(domains.len());
+
+        for domain in domains {
+            let files = self
+                .manifest
+                .query_files(&domain)
+                .with_context(|| format!("failed to query files for domain {domain}"))?;
+
+            let mut exportable_size = 0_u64;
+            for file in files {
+                if file.file_type != ManifestFileType::File {
+                    continue;
+                }
+                let file_path = self.original_file_path(&file.file_id);
+                let metadata = fs::metadata(&file_path).with_context(|| {
+                    format!(
+                        "failed to read metadata for file {} in domain {}",
+                        file_path.display(),
+                        domain
+                    )
+                })?;
+                exportable_size += metadata.len();
+            }
+
+            summaries.push(DomainSummary {
+                domain,
+                exportable_size,
+            });
+        }
+
+        Ok(summaries)
     }
 
     pub fn extract_file<F>(&self, domain: &str, dest_dir: &Path, progress_cb: F) -> Result<()>

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use clap::{Parser, Subcommand};
+use clap::{ArgGroup, Parser, Subcommand};
 
 #[derive(Parser, Debug)]
 #[command(version, about)]
@@ -39,6 +39,14 @@ pub enum Command {
         /// Path of the backup archive whose metadata will be shown.
         backup_dir: PathBuf,
     },
+    #[command(
+        group(
+            ArgGroup::new("extract_target")
+                .required(true)
+                .multiple(false)
+                .args(&["domain", "all"])
+        )
+    )]
     Extract {
         /// Path of the backup archive.
         backup_dir: PathBuf,
@@ -47,8 +55,12 @@ pub enum Command {
         out_dir: PathBuf,
 
         /// Domain of the files to extract.
-        #[arg(short, long, required = true)]
+        #[arg(short, long, group = "extract_target")]
         domain: Option<String>,
+
+        /// Extract every domain that contains exportable data.
+        #[arg(long, group = "extract_target")]
+        all: bool,
 
         /// Create symbolic links instead of copying files.
         #[arg(short = 'L', long)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -21,8 +21,8 @@ impl Args {
 
     pub fn copy_mode(&self) -> bool {
         match &self.command {
-            Command::Extract { copy, .. } => *copy,
-            Command::Migrate { copy, .. } => *copy,
+            Command::Extract { link, .. } => !*link,
+            Command::Migrate { link, .. } => !*link,
             _ => false,
         }
     }
@@ -50,9 +50,9 @@ pub enum Command {
         #[arg(short, long, required = true)]
         domain: Option<String>,
 
-        /// Copy the files instead of creating symbolic links.
-        #[arg(short, long)]
-        copy: bool,
+        /// Create symbolic links instead of copying files.
+        #[arg(short = 'L', long)]
+        link: bool,
     },
     Migrate {
         /// Path of the backup archive to migrate from.
@@ -65,9 +65,9 @@ pub enum Command {
         #[arg(short, long, required = true)]
         domain: Option<String>,
 
-        /// Copy the files instead of creating symbolic links.
-        #[arg(short, long)]
-        copy: bool,
+        /// Create symbolic links instead of copying files.
+        #[arg(short = 'L', long)]
+        link: bool,
     },
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -15,6 +15,7 @@ impl Args {
             Command::ListDomains { backup_dir } => backup_dir,
             Command::Extract { backup_dir, .. } => backup_dir,
             Command::Migrate { backup_dir, .. } => backup_dir,
+            Command::Info { backup_dir } => backup_dir,
         }
     }
 
@@ -32,6 +33,10 @@ pub enum Command {
     #[command()]
     ListDomains {
         /// Path of the backup archive.
+        backup_dir: PathBuf,
+    },
+    Info {
+        /// Path of the backup archive whose metadata will be shown.
         backup_dir: PathBuf,
     },
     Extract {

--- a/src/db.rs
+++ b/src/db.rs
@@ -3,26 +3,14 @@ use std::path::Path;
 
 use anyhow::{Error as AnyhowError, Result};
 use fallible_iterator::FallibleIterator;
-use rusqlite::Connection as SqliteConnection;
+use rusqlite::{Connection as SqliteConnection, OpenFlags};
 
 pub struct BackupManifest {
     db_conn: SqliteConnection,
 }
 
 impl BackupManifest {
-    pub fn open<P>(path: P) -> Result<Self>
-    where
-        P: AsRef<Path>,
-    {
-        if !path.as_ref().exists() {
-            return Err(anyhow!(
-                "file not exists: {}",
-                path.as_ref().to_string_lossy()
-            ));
-        }
-
-        let db_conn = SqliteConnection::open(path)?;
-
+    fn open_with_connection(db_conn: SqliteConnection) -> Result<Self> {
         // Verify the table schema.
         let mut stmt = db_conn.prepare("PRAGMA table_info('files')")?;
         let rows = stmt.query([])?;
@@ -61,6 +49,42 @@ impl BackupManifest {
         }
 
         Ok(Self { db_conn })
+    }
+
+    pub fn open<P>(path: P) -> Result<Self>
+    where
+        P: AsRef<Path>,
+    {
+        if !path.as_ref().exists() {
+            return Err(anyhow!(
+                "file not exists: {}",
+                path.as_ref().to_string_lossy()
+            ));
+        }
+
+        let db_conn = SqliteConnection::open(path)?;
+        Self::open_with_connection(db_conn)
+    }
+
+    pub fn open_read_only<P>(path: P) -> Result<Self>
+    where
+        P: AsRef<Path>,
+    {
+        if !path.as_ref().exists() {
+            return Err(anyhow!(
+                "file not exists: {}",
+                path.as_ref().to_string_lossy()
+            ));
+        }
+
+        let path_ref = path.as_ref();
+        let uri = format!("file:{}?mode=ro&immutable=1", path_ref.display());
+        let db_conn = SqliteConnection::open_with_flags(
+            uri,
+            OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_URI,
+        )?;
+
+        Self::open_with_connection(db_conn)
     }
 
     pub fn query_domains(&self) -> Result<Vec<String>> {

--- a/src/db.rs
+++ b/src/db.rs
@@ -95,6 +95,20 @@ impl BackupManifest {
         Ok(rows.map(|r| r.get(0)).collect()?)
     }
 
+    pub fn file_count(&self) -> Result<usize> {
+        let mut stmt = self.db_conn.prepare("SELECT COUNT(*) FROM files")?;
+        let count: i64 = stmt.query_row([], |r| r.get(0))?;
+        Ok(count as usize)
+    }
+
+    pub fn domain_count(&self) -> Result<usize> {
+        let mut stmt = self
+            .db_conn
+            .prepare("SELECT COUNT(DISTINCT domain) FROM files")?;
+        let count: i64 = stmt.query_row([], |r| r.get(0))?;
+        Ok(count as usize)
+    }
+
     pub fn query_files(&self, domain: &str) -> Result<Vec<ManifestFile>> {
         let mut stmt = self
             .db_conn

--- a/src/fs_index.rs
+++ b/src/fs_index.rs
@@ -183,7 +183,6 @@ impl<'p> EntryType<'p> {
 
 #[cfg(test)]
 mod tests {
-    use std::assert_matches::assert_matches;
     use std::collections::HashMap;
 
     use super::FileSystemIndex;
@@ -199,7 +198,7 @@ mod tests {
         let mut assert_add_file = |path: &str, file_id: &str| {
             let res = index.add_file(path, file_id.to_owned());
             added_files.insert(path.to_owned(), file_id.to_owned());
-            assert_matches!(res, Ok(()));
+            assert!(res.is_ok());
         };
 
         assert_add_file("Library/Cookies/a", "a");
@@ -214,7 +213,7 @@ mod tests {
             }
             Ok(())
         });
-        assert_matches!(res, Ok(()));
+        assert!(res.is_ok());
         assert_eq!(added_files.len(), 0);
     }
 }

--- a/src/fs_index.rs
+++ b/src/fs_index.rs
@@ -1,4 +1,4 @@
-use std::collections::{hash_map, HashMap};
+use std::collections::{HashMap, hash_map};
 use std::path::{Component as PathComponent, Path};
 use std::result::Result as StdResult;
 

--- a/src/info.rs
+++ b/src/info.rs
@@ -1,4 +1,5 @@
 use crate::db::BackupManifest;
+use crate::utils::format_bytes;
 use anyhow::{Context, Result, anyhow};
 use plist::{Dictionary, Value};
 use std::{fs, path::Path};
@@ -150,21 +151,4 @@ fn compute_total_size(path: &Path) -> Result<u64> {
     let mut total = 0;
     accumulate(path, &mut total)?;
     Ok(total)
-}
-
-fn format_bytes(bytes: u64) -> String {
-    const KB: f64 = 1024.0;
-    const MB: f64 = KB * 1024.0;
-    const GB: f64 = MB * 1024.0;
-    let size = bytes as f64;
-
-    if size < KB {
-        format!("{bytes} B")
-    } else if size < MB {
-        format!("{:.2} KiB", size / KB)
-    } else if size < GB {
-        format!("{:.2} MiB", size / MB)
-    } else {
-        format!("{:.2} GiB", size / GB)
-    }
 }

--- a/src/info.rs
+++ b/src/info.rs
@@ -82,7 +82,7 @@ pub fn print_backup_info(
 
     println!("Backup information:");
     for (label, value) in rows {
-        println!("{label:24} {}", value);
+        println!("{label:24} {value}");
     }
 
     Ok(())

--- a/src/info.rs
+++ b/src/info.rs
@@ -1,0 +1,170 @@
+use crate::db::BackupManifest;
+use anyhow::{Context, Result, anyhow};
+use plist::{Dictionary, Value};
+use std::{fs, path::Path};
+
+pub fn print_backup_info(
+    backup_dir: &Path,
+    manifest_path: &Path,
+    manifest: &BackupManifest,
+) -> Result<()> {
+    let info_plist = load_plist(backup_dir.join("Info.plist"))?;
+    let status_plist = load_plist(backup_dir.join("Status.plist"))?;
+
+    let mut rows = Vec::new();
+    rows.push(("Backup path", backup_dir.display().to_string()));
+    rows.push(("Manifest path", manifest_path.display().to_string()));
+
+    if let Some(status) = status_plist.as_ref() {
+        push_row(&mut rows, "Status date", get_date(status, "Date"));
+        push_row(
+            &mut rows,
+            "Status last completed",
+            get_date(status, "Last Completed Backup Date"),
+        );
+        push_row(
+            &mut rows,
+            "Encrypted",
+            get_bool(status, "WasEncrypted").or_else(|| Some("unknown".into())),
+        );
+    }
+
+    if let Some(info) = info_plist.as_ref() {
+        push_row(
+            &mut rows,
+            "Info last backup",
+            get_date(info, "Last Backup Date"),
+        );
+        push_row(&mut rows, "Device", get_string(info, "Device Name"));
+        push_row(&mut rows, "Display name", get_string(info, "Display Name"));
+        push_row(&mut rows, "Product name", get_string(info, "Product Name"));
+        push_row(
+            &mut rows,
+            "Product version",
+            get_string(info, "Product Version"),
+        );
+        push_row(&mut rows, "Product type", get_string(info, "Product Type"));
+        push_row(
+            &mut rows,
+            "Target identifier",
+            get_string(info, "Target Identifier"),
+        );
+        push_row(&mut rows, "GUID", get_string(info, "GUID"));
+        push_row(&mut rows, "UDID", get_string(info, "Unique Identifier"));
+        push_row(
+            &mut rows,
+            "Serial number",
+            get_string(info, "Serial Number"),
+        );
+        push_row(&mut rows, "IMEI", get_string(info, "IMEI"));
+        push_row(&mut rows, "MEID", get_string(info, "MEID"));
+        push_row(&mut rows, "Phone number", get_string(info, "Phone Number"));
+        push_row(
+            &mut rows,
+            "iTunes version",
+            get_string(info, "iTunes Version"),
+        );
+    }
+
+    let total_files = manifest
+        .file_count()
+        .context("failed to count files in manifest")?;
+    let total_domains = manifest
+        .domain_count()
+        .context("failed to count domains in manifest")?;
+    let total_size =
+        compute_total_size(backup_dir).context("failed to compute total backup size on disk")?;
+
+    rows.push(("Total files", total_files.to_string()));
+    rows.push(("Total domains", total_domains.to_string()));
+    rows.push(("Total size", format_bytes(total_size)));
+
+    println!("Backup information:");
+    for (label, value) in rows {
+        println!("{label:24} {}", value);
+    }
+
+    Ok(())
+}
+
+fn load_plist(path: impl AsRef<Path>) -> Result<Option<Dictionary>> {
+    let path = path.as_ref();
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    let value = Value::from_file(path)
+        .with_context(|| format!("failed to read plist: {}", path.display()))?;
+    match value {
+        Value::Dictionary(dict) => Ok(Some(dict)),
+        _ => Err(anyhow!("{} is not a dictionary plist", path.display())),
+    }
+}
+
+fn get_string(dictionary: &Dictionary, key: &str) -> Option<String> {
+    dictionary
+        .get(key)
+        .and_then(|value| value.as_string().map(|s| s.to_owned()))
+}
+
+fn get_bool(dictionary: &Dictionary, key: &str) -> Option<String> {
+    dictionary
+        .get(key)
+        .and_then(|value| value.as_boolean())
+        .map(|value| {
+            if value {
+                "yes".to_owned()
+            } else {
+                "no".to_owned()
+            }
+        })
+}
+
+fn get_date(dictionary: &Dictionary, key: &str) -> Option<String> {
+    dictionary
+        .get(key)
+        .and_then(|value| value.as_date().map(|dt| dt.to_xml_format()))
+}
+
+fn push_row(rows: &mut Vec<(&'static str, String)>, label: &'static str, value: Option<String>) {
+    if let Some(value) = value {
+        rows.push((label, value));
+    }
+}
+
+fn compute_total_size(path: &Path) -> Result<u64> {
+    fn accumulate(path: &Path, total: &mut u64) -> Result<()> {
+        for entry in fs::read_dir(path)? {
+            let entry = entry?;
+            let metadata = entry.metadata()?;
+            let entry_path = entry.path();
+            if metadata.is_dir() {
+                accumulate(&entry_path, total)?;
+            } else if metadata.is_file() {
+                *total += metadata.len();
+            }
+        }
+        Ok(())
+    }
+
+    let mut total = 0;
+    accumulate(path, &mut total)?;
+    Ok(total)
+}
+
+fn format_bytes(bytes: u64) -> String {
+    const KB: f64 = 1024.0;
+    const MB: f64 = KB * 1024.0;
+    const GB: f64 = MB * 1024.0;
+    let size = bytes as f64;
+
+    if size < KB {
+        format!("{bytes} B")
+    } else if size < MB {
+        format!("{:.2} KiB", size / KB)
+    } else if size < GB {
+        format!("{:.2} MiB", size / MB)
+    } else {
+        format!("{:.2} GiB", size / GB)
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod backup;
 mod cli;
 mod db;
 mod fs_index;
+mod info;
 mod utils;
 
 use backup::Backup;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,3 @@
-#![feature(assert_matches)]
-
 #[macro_use]
 extern crate anyhow;
 

--- a/src/utils/format.rs
+++ b/src/utils/format.rs
@@ -1,0 +1,16 @@
+pub fn format_bytes(bytes: u64) -> String {
+    const KB: f64 = 1024.0;
+    const MB: f64 = KB * 1024.0;
+    const GB: f64 = MB * 1024.0;
+    let size = bytes as f64;
+
+    if size < KB {
+        format!("{bytes} B")
+    } else if size < MB {
+        format!("{:.2} KiB", size / KB)
+    } else if size < GB {
+        format!("{:.2} MiB", size / MB)
+    } else {
+        format!("{:.2} GiB", size / GB)
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,4 +1,6 @@
+mod format;
 mod perf_timer;
 pub mod string_pool;
 
+pub use format::format_bytes;
 pub use perf_timer::PerfTimer;


### PR DESCRIPTION
This prevents a compiler warning in newer versions of Rust. 

README.md file also updated to remove out-of-date statement about nightly requirement.